### PR TITLE
publish uberjar to github releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     parameters:
       daml_sdk_version:
-        type: string  
+        type: string
     docker:
       - image: circleci/openjdk:11.0-jdk
 
@@ -44,13 +44,13 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
       - install_sdk:
-          version: << parameters.daml_sdk_version >>            
-      - run: 
+          version: << parameters.daml_sdk_version >>
+      - run:
            name: Build
            command: |
              export PATH=${HOME}/.daml/bin:${PATH}
              make build
-      - run: 
+      - run:
            name: Test
            command: |
              export PATH=${HOME}/.daml/bin:${PATH}
@@ -58,12 +58,61 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies--{{ checksum "build.sbt" }}             
+          key: v1-dependencies--{{ checksum "build.sbt" }}
+
+  release_to_github:
+    parameters:
+      daml_sdk_version:
+        type: string
+    docker:
+      - image: circleci/openjdk:11.0-jdk
+    working_directory: ~/repo
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+    steps:
+      - checkout
+      # Download and cache sbt dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.sbt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - install_sdk:
+          version: << parameters.daml_sdk_version >>
+      - run:
+          name: release-jar-to-github
+          command: |
+            VERSION="0.0.0-snapshot-$(git show -s --format=%cd --date=format:%Y%m%d HEAD).$(git rev-list --count HEAD).$(git show -s --format=%h --abbrev=8 HEAD)"
+            sed -i "s/version :=.*/version := \"$VERSION\"/" build.sbt
+            make assembly
+            git tag v$VERSION
+            RESPONSE=$(curl --fail \
+                            --silent \
+                            --location \
+                            -H "Authorization: token $GITHUB_TOKEN" \
+                            --data "{\"tag_name\": \"v$VERSION\", \"name\": \"$VERSION\", \"body\": \"Automated release.\"}" \
+                            https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases)
+            UPLOAD_URL="$(echo "$RESPONSE" | jq -r .upload_url | sed -e "s/{?name,label}//")"
+            curl -H "Content-Type: application/zip" \
+                 --include \
+                 --fail \
+                 --silent \
+                 --location \
+                 -H "Authorization: token $GITHUB_TOKEN" \
+                 --data-binary "@target/scala-2.12/authentication-service-assembly-$VERSION.jar" \
+                 "${UPLOAD_URL}?name=ref-ledger-authenticator-$VERSION.jar"
+            git checkout build.sbt
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies--{{ checksum "build.sbt" }}
 
   blackduck_scan:
     parameters:
       daml_sdk_version:
-        type: string  
+        type: string
     docker:
       - image: circleci/openjdk:11.0-jdk
 
@@ -85,7 +134,7 @@ jobs:
             - v1-dependencies-
       - install_sdk:
           version: << parameters.daml_sdk_version >>
-      - run: 
+      - run:
            name: Build
            command: |
              export PATH=${HOME}/.daml/bin:${PATH}
@@ -99,13 +148,18 @@ jobs:
             --detect.excluded.detector.types=SBT \
             --detect.notices.report=true \
             --detect.report.timeout=480 \
-            
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build:
           daml_sdk_version: "1.2.0"
+      - release_to_github:
+          daml_sdk_version: "1.2.0"
+          filters:
+            branches:
+              only: master
 
   blackduck:
     triggers:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ run: $(runner)
 scala-test:
 	sbt test
 
+.PHONY: assembly
+assembly: $(dar)
+	sbt 'set test in assembly := {}' clean assembly
+
 .PHONY: clean
 clean:
 	rm -fr scala-codegen/src

--- a/build.sbt
+++ b/build.sbt
@@ -68,3 +68,32 @@ Compile / unmanagedSourceDirectories += baseDirectory.value / "scala-codegen" / 
 enablePlugins(PackPlugin)
 
 packMain := Map("authentication-service" -> "com.projectdabl.authenticationservice.Main")
+
+// There are name clashes between files in some dependencies. The assmebly
+// plugin will by default error out if two files (from different dependencies)
+// with the same name have different content, which is probably better than the
+// default JVM behaviour of depending on classpath order to choose which one to
+// load.
+//
+// See https://github.com/sbt/sbt-assembly#merge-strategy for more info.
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
+ case PathList("google", "protobuf", "field_mask.proto") => MergeStrategy.discard
+ case PathList("module-info.class") => MergeStrategy.discard
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "KeyForDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "KeyForType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "MonotonicNonNullDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NonNullDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "PolyNullDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "MonotonicNonNullType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NonNullType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NullableDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NullableType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "PolyNullType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "MonotonicNonNullType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NonNullType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NullableDecl.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "NullableType.class") => MergeStrategy.first
+ case PathList("org", "checkerframework", "checker", "nullness", "compatqual", "PolyNullType.class") => MergeStrategy.first
+ case x => (assemblyMergeStrategy in assembly).value(x)
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.12")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11")
+
+// https://github.com/sbt/sbt-assembly
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
This PR sets up the basic infrastructure to publish an uberjar (standalone executable) as a GitHub release for each commit to master.

There are two important related concepts this PR does not touch on:

- How do trigger releases. Instead, this just publishes all commits.
- How to decide on a version number. This PR just uses 0.0.0 for all versions (followed by the same snapshot tag format as the DAML repo).