### PR TITLE
bundle dar file and use by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+src/main/resources/daml.dar
 scala-codegen/
 .daml/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ daml_src_path := $(shell find daml/ -type f -name "*.daml")
 # targets
 runner := target/pack/bin/authentication-service # see dockerfile
 dar    := .daml/dist/authentication-service-3.0.0.dar
+bundled-dar := src/main/resources/daml.dar
 
 .PHONY: all
 all: build
@@ -18,7 +19,7 @@ $(dar): $(daml_src_path)
 	daml build # see daml.yaml for more parameters
 	daml codegen scala
 
-$(runner): $(src_path) $(dar)
+$(runner): $(src_path) $(dar) $(bundled-dar)
 	sbt pack
 
 .PHONY: test
@@ -32,12 +33,16 @@ run: $(runner)
 scala-test:
 	sbt test
 
+$(bundled-dar): $(dar)
+	cp $< $@
+
 .PHONY: assembly
-assembly: $(dar)
+assembly: $(dar) $(bundled-dar)
 	sbt 'set test in assembly := {}' clean assembly
 
 .PHONY: clean
 clean:
 	rm -fr scala-codegen/src
 	rm -f $(dar)
+	rm -f $(bundled-dar)
 	sbt clean

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,7 +19,6 @@ authentication-service {
     url = "http://localhost:6865"
     url = ${?DABL_AUTHENTICATION_SERVICE_LEDGER_URL}
 
-    preloadPath = ".daml/dist/authentication-service-3.0.0.dar"
     preloadPath = ${?DABL_AUTHENTICATION_SERVICE_LEDGER_PRELOAD_PATH}
 
     serviceParty = "AuthenticationServiceOperator"

--- a/src/main/scala/com/projectdabl/authenticationservice/config/AuthenticationServiceConfig.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/config/AuthenticationServiceConfig.scala
@@ -8,6 +8,8 @@ import java.time.Duration
 
 import com.typesafe.config.Config
 
+import scala.util.Try
+
 object AuthenticationServiceConfig {
   def apply(config: Config): AuthenticationServiceConfig =
     AuthenticationServiceConfig(
@@ -18,7 +20,7 @@ object AuthenticationServiceConfig {
       ),
       LedgerConfig(
         ledgerUrl = config.getString("ledger.url"),
-        preloadPath = config.getString("ledger.preloadPath"),
+        preloadPath = Try { config.getString("ledger.preloadPath") }.toOption,
         serviceParty = config.getString("ledger.serviceParty")
       ),
       JwtConfig(
@@ -48,7 +50,7 @@ final case class AuthenticationServiceConfig(
 
 final case class ServiceConfig(address: String, port: Int, allowedConsoleOrigin: String)
 
-final case class LedgerConfig(ledgerUrl: String, preloadPath: String, serviceParty: String)
+final case class LedgerConfig(ledgerUrl: String, preloadPath: Option[String], serviceParty: String)
 
 final case class JwtConfig(issuer: String, validityDuration: Duration)
 


### PR DESCRIPTION
This PR bundles the default dar file in the uberjar and uses it if no alternative is provided (by setting the `DABL_AUTHENTICATION_SERVICE_LEDGER_PRELOAD_PATH` env var).