### PR TITLE
downgrade to jdk 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       daml_sdk_version:
         type: string
     docker:
-      - image: circleci/openjdk:11.0-jdk
+      - image: circleci/openjdk:8-jdk
 
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project uses a makefile to order its build steps, and Scala codegen, which i
 
 ## Dependencies
 
-* JDK >= 11
+* JDK >= 8
 * Daml SDK >= 1.2.0
 
 ## Related

--- a/src/main/scala/com/projectdabl/authenticationservice/Main.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/Main.scala
@@ -125,7 +125,7 @@ object Main extends LazyLogging {
             rsaKeyPair,
             keyId,
             serviceConfig.jwtConfig.issuer,
-            Duration(serviceConfig.jwtConfig.validityDuration.toSeconds, SECONDS)
+            Duration(serviceConfig.jwtConfig.validityDuration.getSeconds, SECONDS)
           ),
           cubbyHole,
           serviceConfig.serviceConfig

--- a/src/main/scala/com/projectdabl/authenticationservice/events/LedgerEventHandler.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/events/LedgerEventHandler.scala
@@ -134,7 +134,7 @@ class LedgerEventHandler(val ledgerClient: LedgerClient,
         val salt = codeGenerator.genCode(serviceAccountConfig.saltLength)
         val hash = expandKey(credential, salt)
         val issueTime = readClock()
-        val expiryTime = readClock(issueTime.plus(serviceAccountConfig.validityDuration.toSeconds, ChronoUnit.SECONDS))
+        val expiryTime = readClock(issueTime.plus(serviceAccountConfig.validityDuration.getSeconds, ChronoUnit.SECONDS))
 
         cubbyHole.put(CredentialCoordinate(saCredRequestC.value.owner, credentialId), credential)
 


### PR DESCRIPTION
The DAML project is still using JDK 8, so this PR makes the code compatible with that. To avoid future breakages, it also downgrades the compiler used on CI to 8.