### PR TITLE
add an authorization mode that's suitable for unit tests

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,6 +4,9 @@ akka {
 }
 
 authentication-service {
+  testMode = false
+  testMode = ${?DABL_AUTHENTICATION_SERVICE_TEST_MODE}
+
   service {
     address = "localhost"
     address = ${?DABL_AUTHENTICATION_SERVICE_ADDRESS}

--- a/src/main/scala/com/projectdabl/authenticationservice/api/ApiResponses.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/api/ApiResponses.scala
@@ -4,9 +4,14 @@
 package com.projectdabl.authenticationservice.api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import com.projectdabl.authenticationservice.api.ServiceAccountProtocol.jsonFormat1
 import spray.json.DefaultJsonProtocol
 
 case class UserIdentity(userId: String)
+
+object UserIdentityProtocol extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val uip = jsonFormat1(UserIdentity)
+}
 
 // service account token
 final case class ServiceAccountIdentity(
@@ -15,11 +20,12 @@ final case class ServiceAccountIdentity(
   ledgerId: String
 )
 
-case class ServiceAccountCredentialResponse(credId: String,
-                                            nonce: Option[String] = None,
-                                            cred: Option[String] = None,
-                                            validFrom: Option[String] = None,
-                                            validTo: Option[String] = None)
+case class ServiceAccountCredentialResponse(
+  credId: String,
+  nonce: Option[String] = None,
+  cred: Option[String] = None,
+  validFrom: Option[String] = None,
+  validTo: Option[String] = None)
 
 case class ServiceAccountResponse(
   serviceAccount: String,
@@ -29,8 +35,6 @@ case class ServiceAccountResponse(
 
 case class ServiceAccountListResponse(serviceAccounts: List[ServiceAccountResponse])
 
-case class ServiceAccountTokenResponse(token: String)
-
 object ServiceAccountIdentityProtocol extends DefaultJsonProtocol {
   implicit val saip = jsonFormat3(ServiceAccountIdentity)
 }
@@ -39,6 +43,11 @@ object ServiceAccountProtocol extends SprayJsonSupport with DefaultJsonProtocol 
   implicit val sacp = jsonFormat5(ServiceAccountCredentialResponse)
   implicit val sap = jsonFormat3(ServiceAccountResponse)
   implicit val sasp = jsonFormat1(ServiceAccountListResponse)
-  implicit val satp = jsonFormat1(ServiceAccountTokenResponse)
+}
+
+case class JwtTokenResponse(token: String)
+
+object JwtTokenResponseProtocol extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val jtp = jsonFormat1(JwtTokenResponse)
 }
 

--- a/src/main/scala/com/projectdabl/authenticationservice/config/AuthenticationServiceConfig.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/config/AuthenticationServiceConfig.scala
@@ -13,26 +13,29 @@ import scala.util.Try
 object AuthenticationServiceConfig {
   def apply(config: Config): AuthenticationServiceConfig =
     AuthenticationServiceConfig(
-      ServiceConfig(
+      testMode = config.getBoolean("testMode"),
+      serviceConfig = ServiceConfig(
         address = config.getString("service.address"),
         port = config.getInt("service.port"),
         allowedConsoleOrigin = config.getString("service.allowedConsoleOrigin")
       ),
-      LedgerConfig(
+      ledgerConfig = LedgerConfig(
         ledgerUrl = config.getString("ledger.url"),
-        preloadPath = Try { config.getString("ledger.preloadPath") }.toOption,
+        preloadPath = Try {
+          config.getString("ledger.preloadPath")
+        }.toOption,
         serviceParty = config.getString("ledger.serviceParty")
       ),
-      JwtConfig(
+      jwtConfig = JwtConfig(
         issuer = config.getString("jwt.issuer"),
         validityDuration = config.getDuration("jwt.validityDuration")
       ),
-      JwksConfig(
+      jwksConfig = JwksConfig(
         new URL(config.getString("jwks.endpoint")), // note: throws
         connTimeout = config.getDuration("jwks.connTimeout"),
         readTimeout = config.getDuration("jwks.readTimeout")
       ),
-      ServiceAccountConfig(
+      serviceAccountConfig = ServiceAccountConfig(
         config.getDuration("serviceAccount.validityDuration"),
         config.getInt("serviceAccount.credLength"),
         config.getInt("serviceAccount.saltLength")
@@ -41,12 +44,12 @@ object AuthenticationServiceConfig {
 }
 
 final case class AuthenticationServiceConfig(
+  testMode: Boolean,
   serviceConfig: ServiceConfig,
   ledgerConfig: LedgerConfig,
   jwtConfig: JwtConfig,
   jwksConfig: JwksConfig,
-  serviceAccountConfig: ServiceAccountConfig
-)
+  serviceAccountConfig: ServiceAccountConfig)
 
 final case class ServiceConfig(address: String, port: Int, allowedConsoleOrigin: String)
 

--- a/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
@@ -12,10 +12,11 @@ import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, OPTIONS, POST}
 import akka.http.scaladsl.model.headers.{`Access-Control-Allow-Credentials`, `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
 import akka.http.scaladsl.model.{HttpEntity, HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.directives.Credentials
 import akka.http.scaladsl.server.{Directives, Route}
 import com.daml.ledger.client.binding.Primitive
 import com.projectdabl.authenticationservice.api._
-import com.projectdabl.authenticationservice.config.ServiceConfig
+import com.projectdabl.authenticationservice.config.AuthenticationServiceConfig
 import com.projectdabl.authenticationservice.service.cubby.{CredentialCoordinate, CubbyHole}
 import com.projectdabl.authenticationservice.service.jwt.{JwtAuthenticator, JwtMinter}
 import com.projectdabl.authenticationservice.service.ledger.AdminLedgerService
@@ -33,7 +34,7 @@ object ServiceAccountRouteBuilder {
             passwordAuthenticatorService: PasswordAuthenticator,
             jwtMinter: JwtMinter,
             cubbyHole: CubbyHole,
-            serviceConfig: ServiceConfig)
+            authenticationServiceConfig: AuthenticationServiceConfig)
            (implicit ec: ExecutionContext, system: ActorSystem, clock: Clock): ServiceAccountRouteBuilder =
     new ServiceAccountRouteBuilder(
       adminLedgerService,
@@ -42,7 +43,7 @@ object ServiceAccountRouteBuilder {
       passwordAuthenticatorService,
       jwtMinter,
       cubbyHole,
-      serviceConfig)(ec, system, clock)
+      authenticationServiceConfig)(ec, system, clock)
 }
 
 class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
@@ -51,7 +52,7 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
                                  pwAuthService: PasswordAuthenticator,
                                  jwtMinter: JwtMinter,
                                  cubbyHole: CubbyHole,
-                                 serviceConfig: ServiceConfig)
+                                 authenticationServiceConfig: AuthenticationServiceConfig)
                                 (implicit ec: ExecutionContext, system: ActorSystem, clock: Clock)
   extends Directives
     with SprayJsonSupport {
@@ -60,10 +61,11 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
     """[A-Za-z0-9\-]+""".r
 
   import ServiceAccountRequestProtocol._
+  import com.projectdabl.authenticationservice.api.JwtTokenResponseProtocol._
   import com.projectdabl.authenticationservice.api.ServiceAccountProtocol._
 
   val corsHeaders = List(
-    `Access-Control-Allow-Origin`(serviceConfig.allowedConsoleOrigin),
+    `Access-Control-Allow-Origin`(authenticationServiceConfig.serviceConfig.allowedConsoleOrigin),
     `Access-Control-Allow-Credentials`(true),
     `Access-Control-Allow-Headers`("Authorization", "Content-Type", "pragma"),
     `Access-Control-Allow-Methods`(OPTIONS, POST, GET, DELETE)
@@ -77,186 +79,221 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
     }
   }
 
+  def passThroughAuthenticator(credentials: Credentials): Option[UserIdentity] = {
+    if (authenticationServiceConfig.testMode) {
+      credentials match {
+        // NOTE: this is only suitable for a testing run, and doesn't validate the credentials
+        case Credentials.Provided(id) => Some(UserIdentity(id))
+        case _ => None
+      }
+    } else {
+      None
+    }
+  }
+
+  def authorizationRouteBuilder(userIdentity: UserIdentity): Route =
+    extractLog { log =>
+      post {
+        log.info("in POST handler for authorize call with userId {}", userIdentity)
+
+        complete(
+          adminLedgerService.authorizeUser(userIdentity).run.map {
+            case Some(value) =>
+              log.info("completed user authorization with contract id of: {}", value)
+
+              HttpResponse(
+                entity = HttpEntity(
+                  `application/json`,
+                  JwtTokenResponse(token =
+                    jwtMinter.mintSaJwt(
+                      ServiceAccountIdentity(
+                        party = userIdentity.userId,
+                        rights = Seq("read", "write:create", "write:exercise").toList,
+                        ledgerId = ".auth" // refers to the administrative auth ledger
+                      )
+                    )
+                  ).toJson.compactPrint
+                )
+              )
+            case None =>
+              HttpResponse(status = StatusCodes.BadRequest)
+            }
+        )
+      }
+    }
+
   val route: Route = pathPrefix("sa") {
     extractLog { log =>
       concat(
         pathPrefix("secure") {
           respondWithHeaders(corsHeaders) {
-            authenticateOAuth2("", jwtAuthenticator.oauth2Authenticator) { userId =>
-              concat(
-                path("authorize") {
-                  post {
-                    log.info("in POST handler for authorize call with user id: {}", userId)
-
+            concat(
+              path("authorize") {
+                authenticateBasic("", passThroughAuthenticator) { userId =>
+                  authorizationRouteBuilder(userId)
+                }
+              },
+              authenticateOAuth2("", jwtAuthenticator.oauth2Authenticator) { userId =>
+                concat(
+                  path("authorize") {
+                    authorizationRouteBuilder(userId)
+                  },
+                  path("me") {
                     complete(
-                      adminLedgerService.authorizeUser(userId).run.map {
-                        case Some(value) =>
-                          log.info("completed user authorization with: {}", value)
-                          HttpResponse(status = StatusCodes.OK)
+                      adminLedgerService.retrieveUser(userId).run.map {
+                        case Some(user) =>
+                          val userUUID: String = user.user.toString
+                          import spray.json.DefaultJsonProtocol._
+                          import spray.json._
+
+                          HttpResponse(
+                            status = StatusCodes.OK,
+                            entity = HttpEntity(
+                              `application/json`,
+                              JsObject(
+                                "user" -> JsString(userUUID)
+                              ).toJson.prettyPrint
+                            )
+                          )
+
                         case None =>
-                          log.warning("rejected user authorization")
-                          HttpResponse(status = StatusCodes.BadRequest)
+                          HttpResponse(status = StatusCodes.NotFound)
                       }
                     )
-                  }
-                },
-                path("me") {
-                  complete(
-                    adminLedgerService.retrieveUser(userId).run.map {
-                      case Some(user) =>
-                        val userUUID: String = user.user.toString
-                        import spray.json.DefaultJsonProtocol._
-                        import spray.json._
-
-                        HttpResponse(
-                          status = StatusCodes.OK,
-                          entity = HttpEntity(
-                            `application/json`,
-                            JsObject(
-                              "user" -> JsString(userUUID)
-                            ).toJson.prettyPrint
-                          )
-                        )
-
-                      case None =>
-                        HttpResponse(status = StatusCodes.NotFound)
-                    }
-                  )
-                },
-                path("request" / ALPHANUMERIC_ID_DASH_REGEX) { ledgerId =>
-                  post {
-                    entity(as[ServiceAccountRequest]) { serviceAccountRequest =>
-                      log.info("in POST handler for request call with user id: {} and request {}",
-                        userId, serviceAccountRequest)
-
-                      complete(
-                        adminLedgerService
-                          .createServiceAccountRequest(userId, ledgerId, serviceAccountRequest.nonce)
-                          .run
-                          .map {
-                            case Some(value) =>
-                              log.info("completed service account request with: {}", value)
-                              HttpResponse(status = StatusCodes.OK)
-                            case None =>
-                              HttpResponse(status = StatusCodes.BadRequest)
-                          }
-                      )
-                    }
-                  }
-                },
-                pathEndOrSingleSlash {
-                  get {
-                    log.info("in GET handler for sa listing call: {}", userId)
-
-                    complete(
-                      adminLedgerService
-                        .listServiceAccounts(userId)
-                        .run
-                        .map {
-                          case Some(value) =>
-                            ServiceAccountListResponse(
-                              value
-                                .map(_.value)
-                                .map { sa =>
-
-
-                                  ServiceAccountResponse(
-                                    serviceAccount = sa.serviceAccount.toString,
-                                    nonce = sa.nonce,
-                                    creds = sa.credentialIds
-                                      .map(_.toString)
-                                      .map(credId => ServiceAccountCredentialResponse(credId))
-                                      .toList,
-                                  )
-                                }
-                                .toList
-                            )
-                          case None =>
-                            ServiceAccountListResponse(List())
-                        }
-                    )
-                  }
-                },
-                path(ALPHANUMERIC_ID_DASH_REGEX / "credRequest") { saId =>
-                  pathEndOrSingleSlash {
+                  },
+                  path("request" / ALPHANUMERIC_ID_DASH_REGEX) { ledgerId =>
                     post {
-                      log.info(
-                        "in POST handler for sa cred request call with userId {} and saID {}",
-                        userId, saId)
-
-                      complete(
-                        adminLedgerService.createServiceAccountCredentialRequest(userId, saId).run.map {
-                          case Some(value) =>
-                            log.info("created service account credential request with: {}", value)
-
-                            HttpResponse(status = StatusCodes.OK)
-                          case None =>
-                            HttpResponse(status = StatusCodes.BadRequest)
-                        }
-                      )
-                    }
-                  }
-                },
-                path("cred" / ALPHANUMERIC_ID_DASH_REGEX) { credentialId =>
-                  pathEndOrSingleSlash {
-                    concat(
-                      get {
-                        log.info("in GET handler for sa credential read with userId {} and credId {}",
-                          userId,
-                          credentialId)
-
-                        def formattedUTC(timestamp: Primitive.Timestamp) =
-                          timestamp
-                            .atZone(ZoneId.of("UTC"))
-                            .format(DateTimeFormatter.ISO_INSTANT)
+                      entity(as[ServiceAccountRequest]) { serviceAccountRequest =>
+                        log.info("in POST handler for request call with user id: {} and request {}",
+                          userId, serviceAccountRequest)
 
                         complete(
                           adminLedgerService
-                            .fetchServiceAccountCredentialHashById(userId, credentialId)
+                            .createServiceAccountRequest(userId, ledgerId, serviceAccountRequest.nonce)
                             .run
-                            .recover {
-                              case ex =>
-                                log.warning("failed to fetch credential for user {} with id {}",
-                                  userId, credentialId, ex)
-                                None
-                            }
                             .map {
                               case Some(value) =>
-                                HttpResponse(
-                                  entity = HttpEntity(
-                                    `application/json`,
-                                    string = ServiceAccountCredentialResponse(
-                                      credId = value.credentialId,
-                                      nonce = Some(value.nonce.toString),
-                                      cred = cubbyHole.remove(CredentialCoordinate(value.owner, value.credentialId)),
-                                      validFrom = Some(formattedUTC(value.validFrom)),
-                                      validTo = Some(formattedUTC(value.validTo))
-                                    ).toJson.prettyPrint
-                                  )
-                                )
+                                log.info("completed service account request with: {}", value)
+                                HttpResponse(status = StatusCodes.OK)
                               case None =>
-                                HttpResponse(status = StatusCodes.NotFound)
+                                HttpResponse(status = StatusCodes.BadRequest)
                             }
                         )
-                      },
-                      delete {
-                        log.info("in DELETE handler for sa credential with userId {}", userId)
+                      }
+                    }
+                  },
+                  pathEndOrSingleSlash {
+                    get {
+                      log.info("in GET handler for sa listing call: {}", userId)
+
+                      complete(
+                        adminLedgerService
+                          .listServiceAccounts(userId)
+                          .run
+                          .map {
+                            case Some(value) =>
+                              ServiceAccountListResponse(
+                                value
+                                  .map(_.value)
+                                  .map { sa =>
+                                    ServiceAccountResponse(
+                                      serviceAccount = sa.serviceAccount.toString,
+                                      nonce = sa.nonce,
+                                      creds = sa.credentialIds
+                                        .map(_.toString)
+                                        .map(credId => ServiceAccountCredentialResponse(credId))
+                                        .toList,
+                                    )
+                                  }
+                                  .toList
+                              )
+                            case None =>
+                              ServiceAccountListResponse(List())
+                          }
+                      )
+                    }
+                  },
+                  path(ALPHANUMERIC_ID_DASH_REGEX / "credRequest") { saId =>
+                    pathEndOrSingleSlash {
+                      post {
+                        log.info(
+                          "in POST handler for sa cred request call with userId {} and saID {}",
+                          userId, saId)
 
                         complete(
-                          adminLedgerService.deleteServiceAccountCredentialHashById(userId, credentialId).run.map {
+                          adminLedgerService.createServiceAccountCredentialRequest(userId, saId).run.map {
                             case Some(value) =>
-                              log.info("completed service account deletion with {}", value)
+                              log.info("created service account credential request with: {}", value)
+
                               HttpResponse(status = StatusCodes.OK)
                             case None =>
                               HttpResponse(status = StatusCodes.BadRequest)
                           }
                         )
                       }
-                    )
+                    }
+                  },
+                  path("cred" / ALPHANUMERIC_ID_DASH_REGEX) { credentialId =>
+                    pathEndOrSingleSlash {
+                      concat(
+                        get {
+                          log.info("in GET handler for sa credential read with userId {} and credId {}",
+                            userId,
+                            credentialId)
+
+                          def formattedUTC(timestamp: Primitive.Timestamp) =
+                            timestamp
+                              .atZone(ZoneId.of("UTC"))
+                              .format(DateTimeFormatter.ISO_INSTANT)
+
+                          complete(
+                            adminLedgerService
+                              .fetchServiceAccountCredentialHashById(userId, credentialId)
+                              .run
+                              .recover {
+                                case ex =>
+                                  log.warning("failed to fetch credential for user {} with id {}",
+                                    userId, credentialId, ex)
+                                  None
+                              }
+                              .map {
+                                case Some(value) =>
+                                  HttpResponse(
+                                    entity = HttpEntity(
+                                      `application/json`,
+                                      string = ServiceAccountCredentialResponse(
+                                        credId = value.credentialId,
+                                        nonce = Some(value.nonce.toString),
+                                        cred = cubbyHole.remove(CredentialCoordinate(value.owner, value.credentialId)),
+                                        validFrom = Some(formattedUTC(value.validFrom)),
+                                        validTo = Some(formattedUTC(value.validTo))
+                                      ).toJson.prettyPrint
+                                    )
+                                  )
+                                case None =>
+                                  HttpResponse(status = StatusCodes.NotFound)
+                              }
+                          )
+                        },
+                        delete {
+                          log.info("in DELETE handler for sa credential with userId {}", userId)
+
+                          complete(
+                            adminLedgerService.deleteServiceAccountCredentialHashById(userId, credentialId).run.map {
+                              case Some(value) =>
+                                log.info("completed service account deletion with {}", value)
+                                HttpResponse(status = StatusCodes.OK)
+                              case None =>
+                                HttpResponse(status = StatusCodes.BadRequest)
+                            }
+                          )
+                        }
+                      )
+                    }
                   }
-                }
-              )
-            }
+                )
+              }
+            )
           }
         },
         pathPrefix("secure") {
@@ -288,8 +325,8 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
                 log.info("in POST handler for sa login: {}", saCredHash)
 
                 complete(
-                  ServiceAccountTokenResponse(token =
-                    jwtMinter.mintJwt(
+                  JwtTokenResponse(token =
+                    jwtMinter.mintSaJwt(
                       ServiceAccountIdentity(
                         party = saCredHash.serviceAccount.toString,
                         rights = Seq("read", "write:create", "write:exercise").toList,

--- a/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtJwkAuthenticatorImpl.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtJwkAuthenticatorImpl.scala
@@ -11,9 +11,9 @@ import pdi.jwt.{JwtAlgorithm, JwtOptions, JwtSprayJson}
 
 import scala.util.Try
 
-object JwtAuthenticatorImpl {
-  def apply(jwksConfig: JwksConfig): JwtAuthenticatorImpl =
-    new JwtAuthenticatorImpl(
+object JwtJwkAuthenticatorImpl {
+  def apply(jwksConfig: JwksConfig): JwtJwkAuthenticatorImpl =
+    new JwtJwkAuthenticatorImpl(
       new GuavaCachedJwkProvider(
         new UrlJwkProvider(
           jwksConfig.endpoint,
@@ -24,7 +24,7 @@ object JwtAuthenticatorImpl {
     )
 }
 
-class JwtAuthenticatorImpl(jwkProvider: JwkProvider) extends JwtAuthenticator {
+class JwtJwkAuthenticatorImpl(jwkProvider: JwkProvider) extends JwtAuthenticator {
   override def oauth2Authenticator(creds: Credentials): Option[UserIdentity] =
     creds match {
       case Credentials.Missing => None

--- a/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtMinter.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtMinter.scala
@@ -5,9 +5,9 @@ package com.projectdabl.authenticationservice.service.jwt
 
 import java.time.Clock
 
-import com.projectdabl.authenticationservice.api.ServiceAccountIdentity
+import com.projectdabl.authenticationservice.api.{ServiceAccountIdentity, UserIdentity}
 
 trait JwtMinter {
-  def mintJwt(serviceAccountIdentity: ServiceAccountIdentity)(implicit clock: Clock): String
+  def mintSaJwt(serviceAccountIdentity: ServiceAccountIdentity)(implicit clock: Clock): String
 }
 

--- a/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtMinterImpl.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/jwt/JwtMinterImpl.scala
@@ -3,7 +3,6 @@
 
 package com.projectdabl.authenticationservice.service.jwt
 
-
 import java.time.Clock
 
 import com.projectdabl.authenticationservice.api.ServiceAccountIdentity
@@ -25,16 +24,19 @@ class JwtMinterImpl(rsaKeyPair: RSAKeyPair,
 
   import com.projectdabl.authenticationservice.api.ServiceAccountIdentityProtocol._
 
-  override def mintJwt(serviceAccountIdentity: ServiceAccountIdentity)(implicit clock: Clock): String =
-    JwtSprayJson.encode(
-      JwtHeader(JwtAlgorithm.RS256)
-        .withKeyId(keyId),
+  override def mintSaJwt(serviceAccountIdentity: ServiceAccountIdentity)(implicit clock: Clock): String =
+    mintTokenWithClaim(
       JwtClaim()
         .about(serviceAccountIdentity.party)
         .withContent(serviceAccountIdentity.toJson.compactPrint)
         .by(issuer)
-        .expiresIn(validityDuration.toSeconds),
-      rsaKeyPair.privateKey
+        .expiresIn(validityDuration.toSeconds)
     )
+
+  private def mintTokenWithClaim(jwtClaim: JwtClaim): String =
+    JwtSprayJson.encode(
+      JwtHeader(JwtAlgorithm.RS256).withKeyId(keyId),
+      jwtClaim,
+      rsaKeyPair.privateKey)
 }
 

--- a/src/main/scala/com/projectdabl/authenticationservice/service/jwt/SerialJwtAuthenticator.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/jwt/SerialJwtAuthenticator.scala
@@ -1,0 +1,22 @@
+package com.projectdabl.authenticationservice.service.jwt
+
+import akka.http.scaladsl.server.directives.Credentials
+import com.projectdabl.authenticationservice.api.UserIdentity
+
+object SerialJwtAuthenticator {
+  def apply(jwtAuthenticators: Seq[JwtAuthenticator]): SerialJwtAuthenticator =
+    new SerialJwtAuthenticator(jwtAuthenticators)
+}
+
+class SerialJwtAuthenticator(jwtAuthenticators: Seq[JwtAuthenticator]) extends JwtAuthenticator {
+  override def oauth2Authenticator(creds: Credentials): Option[UserIdentity] =
+    oauth2Authenticator(creds, jwtAuthenticators)
+
+  private def oauth2Authenticator(creds: Credentials,
+                                  jwtAuthenticators: Seq[JwtAuthenticator]): Option[UserIdentity] =
+    if (jwtAuthenticators.isEmpty) {
+      None
+    } else {
+      jwtAuthenticators.head.oauth2Authenticator(creds).orElse(oauth2Authenticator(creds, jwtAuthenticators.tail))
+    }
+}

--- a/src/main/scala/com/projectdabl/authenticationservice/service/jwt/StaticJwtAuthenticator.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/jwt/StaticJwtAuthenticator.scala
@@ -1,0 +1,25 @@
+package com.projectdabl.authenticationservice.service.jwt
+
+import java.security.interfaces.RSAPublicKey
+
+import akka.http.scaladsl.server.directives.Credentials
+import com.projectdabl.authenticationservice.api.UserIdentity
+import pdi.jwt.{JwtAlgorithm, JwtSprayJson}
+
+object StaticJwtAuthenticator {
+  def apply(rsaPublicKey: RSAPublicKey): StaticJwtAuthenticator = new StaticJwtAuthenticator(rsaPublicKey)
+}
+
+class StaticJwtAuthenticator(rsaPublicKey: RSAPublicKey) extends JwtAuthenticator {
+  override def oauth2Authenticator(creds: Credentials): Option[UserIdentity] =
+    creds match {
+      case Credentials.Missing => None
+      case Credentials.Provided(bearerToken) => authenticateToken(bearerToken)
+    }
+
+  private def authenticateToken(bearerToken: String): Option[UserIdentity] =
+    for {
+      validatedClaim <- JwtSprayJson.decode(bearerToken, rsaPublicKey, Seq(JwtAlgorithm.RS256)).toOption
+      sub <- validatedClaim.subject
+    } yield UserIdentity(sub)
+}

--- a/src/test/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilderSpec.scala
+++ b/src/test/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilderSpec.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server.directives.Credentials
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.daml.ledger.client.binding.Primitive
 import com.projectdabl.authenticationservice.api.ServiceAccountRequestProtocol._
-import com.projectdabl.authenticationservice.api.{UserIdentity, ServiceAccountRequest => APIServiceAccountRequest}
+import com.projectdabl.authenticationservice.api.{ServiceAccountIdentity, UserIdentity, ServiceAccountRequest => APIServiceAccountRequest}
 import com.projectdabl.authenticationservice.config.AuthenticationServiceConfig
 import com.projectdabl.authenticationservice.model.DABL.AuthenticationService.V3._
 import com.projectdabl.authenticationservice.service.cubby.CubbyHole
@@ -113,7 +113,7 @@ class ServiceAccountRouteBuilderSpec
     mockPasswordAuthenticatorService,
     mockJwtMinter,
     mockCubbyHole,
-    authenticationServiceConfig.serviceConfig)
+    authenticationServiceConfig)
 
   val routeUnderTest: Route = sut.route
 
@@ -122,6 +122,10 @@ class ServiceAccountRouteBuilderSpec
       (mockAdminLedgerService.authorizeUser _)
         .expects(testUserIdentity)
         .returns(testUserAuthResult)
+
+      (mockJwtMinter.mintSaJwt(_: ServiceAccountIdentity)(_: Clock))
+        .expects(*, clock)
+        .returns("{}")
 
       Post("/sa/secure/authorize") ~> routeUnderTest ~> check {
         response.status shouldBe (StatusCodes.OK)


### PR DESCRIPTION
## Overview 

This is a change to the service that makes it usable within a unit testing environment in a much simpler way and without requiring trusting another external JWKS vendor.

Effectively the authorize endpoint is now callable with basic auth in addition to being callable with a JWT from an external service, and the internal endpoints are now callable with JWTs from the same service, as well as a JWT from an external service.

Note that the testing mode is toggled by the presence of an environment variable, and should not be used in non test scenarios as the supplied credential is not validated in any way.

## Testing Done

### Unit Test Workflow

* see enclosed changes and CI

### Manual Testing Worfklow

Run the service in test mode:

```
DABL_AUTHENTICATION_SERVICE_TEST_MODE=true make run
```

Create a test user:

```
curl -u user:pass -X POST localhost:8089/sa/secure/authorize
```

Load back the user details:

```
curl -H 'Authorization: Bearer  <the value>' localhost:8089/sa/secure/me
```