### PR TITLE
stricter caches in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,30 @@ commands:
       version:
         type: string
     steps:
+      - restore_cache:
+          keys:
+            - key-{{ checksum "build.sbt" }}-{{ checksum "daml.yaml" }}-{{ checksum ".circleci/config.yml" }}
       - run:
           command: |
             cd ${HOME}
-            wget https://github.com/digital-asset/daml/releases/download/v<< parameters.version >>/daml-sdk-<< parameters.version >>-linux.tar.gz
-            tar -zxvf daml-sdk-<< parameters.version >>-linux.tar.gz
-            cd sdk-<< parameters.version >>
-            ./install.sh
-            cd ${HOME}
-            rm -rf sdk-<< parameters.version >>
+            if ! command -v daml >/dev/null; then
+                wget https://github.com/digital-asset/daml/releases/download/v<< parameters.version >>/daml-sdk-<< parameters.version >>-linux.tar.gz
+                tar -zxvf daml-sdk-<< parameters.version >>-linux.tar.gz
+                cd sdk-<< parameters.version >>
+                ./install.sh
+                cd ${HOME}
+                rm -rf sdk-<< parameters.version >>
+            fi
+  save_deps:
+    description: "save cache"
+    steps:
+      - save_cache:
+          paths:
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.daml
+          key: key-{{ checksum "build.sbt" }}-{{ checksum "daml.yaml" }}-{{ checksum ".circleci/config.yml" }}
 
 jobs:
   build:
@@ -38,11 +53,6 @@ jobs:
     steps:
       - checkout
       # Download and cache sbt dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.sbt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - install_sdk:
           version: << parameters.daml_sdk_version >>
       - run:
@@ -55,17 +65,15 @@ jobs:
            command: |
              export PATH=${HOME}/.daml/bin:${PATH}
              make test
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies--{{ checksum "build.sbt" }}
+      - save_deps
+
 
   release_to_github:
     parameters:
       daml_sdk_version:
         type: string
     docker:
-      - image: circleci/openjdk:11.0-jdk
+      - image: circleci/openjdk:8-jdk
     working_directory: ~/repo
     environment:
       # Customize the JVM maximum heap limit
@@ -73,12 +81,6 @@ jobs:
       TERM: dumb
     steps:
       - checkout
-      # Download and cache sbt dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.sbt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - install_sdk:
           version: << parameters.daml_sdk_version >>
       - run:
@@ -129,17 +131,14 @@ jobs:
                      --data-binary "@$f" \
                      "${UPLOAD_URL}?name=$f"
             done
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies--{{ checksum "build.sbt" }}
+      - save_deps
 
   blackduck_scan:
     parameters:
       daml_sdk_version:
         type: string
     docker:
-      - image: circleci/openjdk:11.0-jdk
+      - image: circleci/openjdk:8-jdk
 
     working_directory: ~/repo
 
@@ -150,13 +149,6 @@ jobs:
 
     steps:
       - checkout
-
-      # Download and cache sbt dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.sbt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - install_sdk:
           version: << parameters.daml_sdk_version >>
       - run:


### PR DESCRIPTION
After #11, I don't think trying to reuse old caches is a good idea anymore.

This commit also changes the JDK used to 8 everywhere, and refactors
the caching code a bit.