### PR TITLE
increase blackduck timeout tolerance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
             --detect.notices.report=true \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
-            --detect.report.timeout=1000 \
+            --detect.report.timeout=3000 \
       - store_artifacts:
           path: /home/circleci/blackduck/runs
 


### PR DESCRIPTION
Try to give more buffer for Blackduck daily job to complete so we are not hit by timeouts as we were in last evening's run
https://app.circleci.com/pipelines/github/digital-asset/ref-ledger-authenticator/85/workflows/9c8dd267-f733-4b85-90f5-c8c0923d2953/jobs/87/steps