### PR TITLE
Try to nurse blackduck job back to health

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
             ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=SBT \
-            --detect.notices.report=true \
+            --detect.notices.report=false \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
             --detect.report.timeout=3600 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             --detect.notices.report=false \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
-            --detect.report.timeout=3600 \
+            --detect.report.timeout=900 \
             
       - store_artifacts:
           path: /home/circleci/blackduck/runs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
             ci-build digitalasset_ref-ledger-authenticator master \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=SBT \
-            --detect.notices.report=true \
+            --detect.notices.report=false \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
             --detect.report.timeout=3000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,13 +160,14 @@ jobs:
           name: Run Blackduck Detect
           command: |
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-            ci-build digitalasset_ref-ledger-authenticator master \
+            ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=SBT \
             --detect.notices.report=false \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
             --detect.report.timeout=3000 \
+            
       - store_artifacts:
           path: /home/circleci/blackduck/runs
 
@@ -183,13 +184,13 @@ workflows:
               only: master
 
   blackduck:
-    triggers:
-      - schedule:
-          cron: "0 8 * * 1-5"
-          filters:
-            branches:
-              only:
-                - master
+#     triggers:
+#       - schedule:
+#           cron: "0 8 * * 1-5"
+#           filters:
+#             branches:
+#               only:
+#                 - master
     jobs:
       - blackduck_scan:
           daml_sdk_version: "1.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,13 +184,13 @@ workflows:
               only: master
 
   blackduck:
-#     triggers:
-#       - schedule:
-#           cron: "0 8 * * 1-5"
-#           filters:
-#             branches:
-#               only:
-#                 - master
+    triggers:
+      - schedule:
+          cron: "0 8 * * 1-5"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - blackduck_scan:
           daml_sdk_version: "1.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,10 +163,10 @@ jobs:
             ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.excluded.detector.types=SBT \
-            --detect.notices.report=false \
+            --detect.notices.report=true \
             --detect.cleanup=false \
             --detect.cleanup.bdio.files=false \
-            --detect.report.timeout=3000 \
+            --detect.report.timeout=3600 \
             
       - store_artifacts:
           path: /home/circleci/blackduck/runs


### PR DESCRIPTION
More tweaking of daily Blackduck job
- Do not wait for notices file and scan completion since it appears to be too lengthy given signature scan evaluation
- Decrease timeout