### PR TITLE
Disable signature scan that seems to be problematic for blackduck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
             ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
+            --detect.tools=DETECTOR,BINARY_SCAN \
             --detect.excluded.detector.types=SBT \
             --detect.notices.report=false \
             --detect.cleanup=false \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,13 +185,13 @@ workflows:
               only: master
 
   blackduck:
-    triggers:
-      - schedule:
-          cron: "0 8 * * 1-5"
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule:
+    #       cron: "0 8 * * 1-5"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
     jobs:
       - blackduck_scan:
           daml_sdk_version: "1.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,13 +185,13 @@ workflows:
               only: master
 
   blackduck:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 8 * * 1-5"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+    triggers:
+      - schedule:
+          cron: "0 8 * * 1-5"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - blackduck_scan:
           daml_sdk_version: "1.2.0"


### PR DESCRIPTION
Still getting weird blackduck failures on the daily scans : disable the signature_scanner for now to stop them
