### PR TITLE
Make "user" in the User template the name of the party

### DIFF
--- a/daml/DABL/AuthenticationService/V3.daml
+++ b/daml/DABL/AuthenticationService/V3.daml
@@ -19,18 +19,18 @@ template Operator
     controller operator can
       nonconsuming OperatorFetchUser : (ContractId User, User)
         with
-          userId : Text
+          user : Party
         do
-          fetchByKey @User (operator, userId)
+          fetchByKey @User (operator, user)
 
       nonconsuming OperatorUpsertPartyAssociation : ContractId User
         with
-          userId         : Text
-          maybeNewUser   : Party -- discarded if there exists an old user
+          user           : Party
+          newUserId      : Party -- discarded if there exists an old user
         do
-          userOpt <- lookupByKey @User (operator, userId)
+          userOpt <- lookupByKey @User (operator, user)
           case userOpt of
-            None -> create User with user = maybeNewUser, ..
+            None -> create User with operator; user; userId = newUserId
             Some existingUserCid -> pure existingUserCid
 
       nonconsuming OperatorFetchServiceAccount : (ContractId ServiceAccount, ServiceAccount)
@@ -45,10 +45,10 @@ template Operator
 template ServiceAccount
   with
     operator         : Party
-    owner            : Party -- points to owning User
+    owner            : Party -- token granting system is hooked up to give access to the owning User
     ledgerId         : Text
     nonce            : Text
-    serviceAccount   : Party -- NOTE: token granting system is hooked up to give access to this party
+    serviceAccount   : Party
     credentialIds    : [Text]
   where
     signatory operator, owner
@@ -154,13 +154,13 @@ template User
   with
     operator      : Party
     user          : Party
-    userId        : Text
+    userId        : Party
   where
     signatory operator
 
     observer user
 
-    key (operator, userId) : (Party, Text)
+    key (operator, user) : (Party, Party)
     maintainer key._1
 
     controller operator can

--- a/daml/Test/AuthenticationService/V3.daml
+++ b/daml/Test/AuthenticationService/V3.daml
@@ -18,16 +18,17 @@ createOrFetchOperatorTest =
         Some cid -> return cid
         None -> create Operator with ..
 
-createUserMappingTest userId party =
+createUserMappingTest username userid =
   scenario do
     operator <- getParty "operator"
+    user <- getParty username
     serviceOperatorCid <- createOrFetchOperatorTest
 
     submit operator do
       exercise serviceOperatorCid OperatorUpsertPartyAssociation
         with
-          userId = userId
-          maybeNewUser = party
+          user
+          newUserId = userid
 
 userDuplicatedRegistration =
   scenario do

--- a/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
@@ -328,7 +328,7 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
                   JwtTokenResponse(token =
                     jwtMinter.mintSaJwt(
                       ServiceAccountIdentity(
-                        party = saCredHash.serviceAccount.toString,
+                        party = saCredHash.owner.toString,
                         rights = Seq("read", "write:create", "write:exercise").toList,
                         ledgerId = saCredHash.ledgerId
                       )

--- a/src/main/scala/com/projectdabl/authenticationservice/service/ledger/AdminLedgerServiceImpl.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/ledger/AdminLedgerServiceImpl.scala
@@ -57,8 +57,8 @@ class AdminLedgerServiceImpl(val ledgerClient: LedgerClient,
                 .exerciseOperatorUpsertPartyAssociation(
                   operatorC.value.operator,
                   OperatorUpsertPartyAssociation(
-                    identity.userId,
-                    genAuthenticationUser()
+                    Primitive.Party(identity.userId),
+                    genAuthenticationUserId()
                   )
                 )
                 .command
@@ -92,7 +92,7 @@ class AdminLedgerServiceImpl(val ledgerClient: LedgerClient,
                 .exerciseOperatorFetchUser(
                   operatorC.value.operator,
                   OperatorFetchUser(
-                    identity.userId
+                    Primitive.Party(identity.userId)
                   )
                 ).command
             )

--- a/src/main/scala/com/projectdabl/authenticationservice/service/ledger/IdGenerator.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/ledger/IdGenerator.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.client.binding.Primitive
 trait IdGenerator {
   private def genLowercaseUUID(): String = UUID.randomUUID().toString.toLowerCase
 
-  def genAuthenticationUser(): Primitive.Party = Primitive.Party(s"sa-user-${genLowercaseUUID()}")
+  def genAuthenticationUserId(): Primitive.Party = Primitive.Party(s"sa-user-${genLowercaseUUID()}")
 
   def genServiceAccount(): Primitive.Party = Primitive.Party(s"sa-${genLowercaseUUID()}")
 

--- a/src/main/scala/com/projectdabl/authenticationservice/service/ledger/user/UserResolver.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/service/ledger/user/UserResolver.scala
@@ -12,6 +12,7 @@ import com.projectdabl.authenticationservice.service.ledger.{CommandBuilder, Tra
 import com.typesafe.scalalogging.LazyLogging
 import scalaz.OptionT
 import scalaz.OptionT.optionT
+import com.daml.ledger.client.binding.Primitive
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -32,7 +33,7 @@ trait UserResolver extends CommandBuilder with TransactionResponseTransformer wi
               operatorC.value.operator,
               operatorC
                 .contractId
-                .exerciseOperatorFetchUser(operatorC.value.operator, userId.userId)
+                .exerciseOperatorFetchUser(operatorC.value.operator, Primitive.Party(userId.userId))
                 .command
             )
           )


### PR DESCRIPTION
When using ref-ledger-authenticator to grant tokens for access to an authenticated ledger, I ran into the problem that the `"party"` field of the token was the service account id instead of the party issuing the command. To me, the party field should represent the party on the ledger being granted access to. In my case I want to run triggers on behalf of such parties, who may appear in contracts on the ledger, so using the service account ids does not make sense to me.