### PR TITLE
Store userId in service account templates and create new login endpoint

### DIFF
--- a/daml/DABL/AuthenticationService/V3.daml
+++ b/daml/DABL/AuthenticationService/V3.daml
@@ -46,6 +46,7 @@ template ServiceAccount
   with
     operator         : Party
     owner            : Party -- points to owning User
+    ownerId          : Text  -- userId of owning User (see user/userId distinction in User template)
     ledgerId         : Text
     nonce            : Text
     serviceAccount   : Party -- NOTE: token granting system is hooked up to give access to this party
@@ -72,6 +73,7 @@ template ServiceAccountCredentialHash
   with
     operator       : Party
     owner          : Party
+    ownerId        : Text
     ledgerId       : Text
     nonce          : Text
     serviceAccount : Party
@@ -97,6 +99,7 @@ template ServiceAccountCredentialRequest
   with
     operator       : Party
     owner          : Party
+    ownerId        : Text
     serviceAccount : Party
     ledgerId       : Text
     nonce          : Text
@@ -127,6 +130,7 @@ template ServiceAccountRequest
   with
     operator : Party
     user     : Party
+    userId   : Text  -- see user/userId distinction in User template
     ledgerId : Text
     nonce    : Text
   where
@@ -143,6 +147,7 @@ template ServiceAccountRequest
         do
           create ServiceAccount with
             owner = user
+            ownerId = userId
             serviceAccount = newServiceAccount
             credentialIds = []
             ..
@@ -153,8 +158,8 @@ template ServiceAccountRequest
 template User
   with
     operator      : Party
-    user          : Party
-    userId        : Text
+    user          : Party -- generated service account user
+    userId        : Text  -- name of party who originally called `authorize`
   where
     signatory operator
 

--- a/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
+++ b/src/main/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilder.scala
@@ -339,6 +339,27 @@ class ServiceAccountRouteBuilder(adminLedgerService: AdminLedgerService,
             }
           }
         },
+        path("loginWithUserId") {
+          authenticateBasicAsync("", pwAuthService.passwordAuthenticateAsync) { saCredHash =>
+            pathEndOrSingleSlash {
+              post {
+                log.info("in POST handler for sa login with user id: {}", saCredHash)
+
+                complete(
+                  JwtTokenResponse(token =
+                    jwtMinter.mintSaJwt(
+                      ServiceAccountIdentity(
+                        party = saCredHash.ownerId.toString,
+                        rights = Seq("read", "write:create", "write:exercise").toList,
+                        ledgerId = saCredHash.ledgerId
+                      )
+                    )
+                  )
+                )
+              }
+            }
+          }
+        },
         path("jwks") {
           get {
             complete(HttpEntity(contentType = `application/json`, string = jwks.toJson))

--- a/src/test/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilderSpec.scala
+++ b/src/test/scala/com/projectdabl/authenticationservice/route/ServiceAccountRouteBuilderSpec.scala
@@ -65,6 +65,7 @@ class ServiceAccountRouteBuilderSpec
           ServiceAccountRequest(
             Primitive.Party("operator"),
             Primitive.Party("user"),
+            "userId",
             testLedgerId,
             testNonce
           )
@@ -79,6 +80,7 @@ class ServiceAccountRouteBuilderSpec
           ServiceAccountCredentialRequest(
             Primitive.Party("operator"),
             Primitive.Party("owner"),
+            "ownerId",
             Primitive.Party("serviceAccount"),
             testLedgerId,
             testNonce


### PR DESCRIPTION
This change provides a new endpoint which is the same as `login` but where the party in the payload is the one that originally called `authorize`, as opposed to the service account user generated for them. This is generally useful for applications to use this service to grant ledger access tokens to existing parties on a ledger as opposed to separate service accounts.

To do this, we need to store the `userId` of the original `User` in the service account related templates.

We had an offline discussion about how prod DABL contracts might move to the new contract model. We could achieve this in two ways:
1. Include logic in the migration script (DAML Script or Trigger?) to figure out the corresponding `userId` for each affected contract. This seems nontrivial as it would involve a query of the ACS by the user party (not id).
2. Make the `userId` field `Optional` everywhere I've introduced it. If DABL does not need the new endpoint then they can migrate by simply adding `None` for the new user ids.

I'm leaning to 2 but open to feedback (e.g. if the migration is actually planned & important, if option 1 is actually not too hard).